### PR TITLE
AT-5109 Fix git protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Wilson Page",
   "license": "BSD",
   "dependencies": {
-    "utils": "git://github.com/wilsonpage/utils.git"
+    "utils": "github:financial-times/ft-app-utils"
   },
   "devDependencies": {
     "buster": "~0.6.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/wilsonpage/extend"
+    "url": "https://github.com/Financial-Times/ft-app-extend"
   },
   "keywords": [
     "inheritance"


### PR DESCRIPTION
* Stop depending on Wilson Page package directly. 
* Stop using git:// protocol
* Github will stop supporting users connecting via SSH or `git://`
* The FT App client is dependent on fruitmachine which is dependent
on this package.
* This update will mean we can continue to build the webapp after 15th
March
* Reference:
https://github.blog/2021-09-01-improving-git-protocol-security-github/